### PR TITLE
Update DigiPotX9Cxxx.cpp

### DIFF
--- a/src/DigiPotX9Cxxx.cpp
+++ b/src/DigiPotX9Cxxx.cpp
@@ -46,7 +46,7 @@ void DigiPot::increase(uint8_t amount) {
 }
 
 void DigiPot::decrease(uint8_t amount) {
-  amount = constrain(amount, 0, DIGIPOT_MAX_AMOUNT);
+  amount = constrain(amount, 0, DIGIPOT_MIN_AMOUNT);
   change(DIGIPOT_DOWN, amount);
 }
 


### PR DESCRIPTION
Fixed bug where negative values in the decrease-method would set the value to DIGIPOT_MAX_AMOUNT instead of DIGIPOT_MIN_AMOUNT