### PR TITLE
add an empty constructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.pio
+.vscode
+src/main.cpp

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 When searching for an arduino library to control X9Cxxx family digital potentiometers, found some old 2011 forum post that just does the job. Unfortunately this library was not available under arduino IDE's library manager. So I decided to put it in there.
 
 
-The original foum post: [click here](https://forum.arduino.cc/t/arduino-library-for-x9c103p-digital-potentiometer/67602)
+The original forum post: [click here](https://forum.arduino.cc/t/arduino-library-for-x9c103p-digital-potentiometer/67602)
 
 
 The original website: [click here](https://sites.google.com/site/tfagerscode/home/digipotx9cxxx)

--- a/src/DigiPotX9Cxxx.cpp
+++ b/src/DigiPotX9Cxxx.cpp
@@ -7,6 +7,20 @@
 #include "Arduino.h"
 #include "DigiPotX9Cxxx.h"
 
+DigiPot::DigiPot() {}
+
+void DigiPot::setup(uint8_t incPin, uint8_t udPin, uint8_t csPin) {
+  _incPin = incPin;
+  _udPin = udPin;
+  _csPin = csPin;  
+  _currentValue = DIGIPOT_UNKNOWN;
+
+  pinMode(_incPin, OUTPUT);
+  pinMode(_udPin, OUTPUT);
+  pinMode(_csPin, OUTPUT);
+  digitalWrite(_csPin, HIGH);
+}
+
 DigiPot::DigiPot(uint8_t incPin, uint8_t udPin, uint8_t csPin) {
   _incPin = incPin;
   _udPin = udPin;

--- a/src/DigiPotX9Cxxx.h
+++ b/src/DigiPotX9Cxxx.h
@@ -17,7 +17,9 @@
 class DigiPot
 {
  public:
+  DigiPot();
   DigiPot(uint8_t incPin, uint8_t udPin, uint8_t csPin);
+  void setup(uint8_t incPin, uint8_t udPin, uint8_t csPin);
   void increase(uint8_t amount);
   void decrease(uint8_t amount);
   void change(uint8_t direction, uint8_t amount);


### PR DESCRIPTION
The use of an empty constructor allows for some more complex and flexible initialization logic without the need to write out every step explicitly.